### PR TITLE
Add Tokenomics page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore build outputs
+flamecoin-site/dist
+flamecoin-site/node_modules
+flamecoin-site/.astro

--- a/flamecoin-site/public/assets/tokenomics.svg
+++ b/flamecoin-site/public/assets/tokenomics.svg
@@ -1,0 +1,5 @@
+<svg width="200" height="200" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="16" cy="16" r="16" fill="#f5f5f5" />
+  <path d="M16 0 A16 16 0 0 1 32 16 L16 16 Z" fill="#ff5c28" />
+  <circle cx="16" cy="16" r="8" fill="white" />
+</svg>

--- a/flamecoin-site/src/layouts/BaseLayout.astro
+++ b/flamecoin-site/src/layouts/BaseLayout.astro
@@ -1,0 +1,14 @@
+---
+const { title, description } = Astro.props;
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <link rel="stylesheet" href="/styles/tokens.css" />
+  </head>
+  <body style="font-family: var(--font-display); background: var(--ash); color: var(--charcoal);">
+    <slot />
+  </body>
+</html>

--- a/flamecoin-site/src/pages/tokenomics.mdx
+++ b/flamecoin-site/src/pages/tokenomics.mdx
@@ -1,0 +1,38 @@
+---
+title: Tokenomics
+description: Overview of supply, allocation, and vesting for FlameCoin.
+layout: ../layouts/BaseLayout.astro
+---
+
+import Donut from "../../public/assets/tokenomics.svg";
+
+# Tokenomics
+
+## Supply
+
+Total supply is **84.5 million FLAME**.
+
+## Circulating
+
+Circulating supply will increase gradually after launch as tokens vest.
+
+## Liquidity
+
+Liquidity pools will be seeded at launch to facilitate trading.
+
+## Burns
+
+Planned burns reduce supply at key milestones to preserve value.
+
+## Roadmap
+
+| Quarter | Milestone |
+| ------- | --------- |
+| Q1 2024 | Token generation event |
+| Q2 2024 | DEX listings |
+| Q3 2024 | Governance launch |
+| Q4 2024 | Ecosystem grants |
+
+<a href="https://explorer.solana.com/address/FLAME_TOKEN_ADDRESS">View on Solana Explorer</a>
+
+<img src="/assets/tokenomics.svg" alt="Token allocation" width="200" height="200" />


### PR DESCRIPTION
## Summary
- add a gitignore for build directories
- create a base layout component
- create tokenomics page using the layout
- add a placeholder donut chart graphic

## Testing
- `npm run build`
- `npx lighthouse dist/tokenomics/index.html --quiet --chrome-flags="--headless" --only-categories=seo,accessibility --no-enable-error-reporting --output=json --output-path=/tmp/lh.json` *(fails: The CHROME_PATH environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6866a9721cb0832ebb95c201aee2041e