### PR TITLE
feat/layout-global-navbar

### DIFF
--- a/flamecoin-site/src/components/Footer.astro
+++ b/flamecoin-site/src/components/Footer.astro
@@ -1,0 +1,3 @@
+<footer class="footer">
+  <!-- TODO: add footer content -->
+</footer>

--- a/flamecoin-site/src/components/NavBar.astro
+++ b/flamecoin-site/src/components/NavBar.astro
@@ -1,0 +1,24 @@
+---
+import './NavBar.css';
+---
+<nav class="navbar">
+  <div class="nav-brand">
+    <a href="/" aria-label="FlameCoin home">
+      <img src="/logo.svg" alt="FlameCoin logo" class="logo" />
+    </a>
+  </div>
+  <input type="checkbox" id="nav-toggle" class="nav-toggle" />
+  <label for="nav-toggle" class="hamburger" aria-label="Menu">
+    <span></span>
+    <span></span>
+    <span></span>
+  </label>
+  <ul class="nav-links">
+    <li><a href="/">Home</a></li>
+    <li><a href="/docs">Docs</a></li>
+    <li><a href="/tech">Tokenomics</a></li>
+    <li><a href="/story">Story</a></li>
+    <li><a href="/team">Team</a></li>
+    <li><a href="/blog">Blog</a></li>
+  </ul>
+</nav>

--- a/flamecoin-site/src/components/NavBar.css
+++ b/flamecoin-site/src/components/NavBar.css
@@ -1,0 +1,58 @@
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--ash);
+  padding: 0.5rem 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+.navbar a {
+  color: var(--charcoal);
+  text-decoration: none;
+  font-weight: bold;
+}
+.nav-brand .logo {
+  height: 40px;
+}
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+}
+.hamburger {
+  display: none;
+  flex-direction: column;
+  cursor: pointer;
+}
+.hamburger span {
+  width: 25px;
+  height: 3px;
+  background: var(--charcoal);
+  margin: 4px 0;
+  transition: 0.4s;
+}
+.nav-toggle {
+  display: none;
+}
+@media (max-width: 768px) {
+  .nav-links {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    padding: 0.5rem 0;
+    background: var(--ash);
+  }
+  .nav-links li {
+    text-align: center;
+    padding: 0.5rem 0;
+  }
+  .nav-toggle:checked + .hamburger + .nav-links {
+    display: flex;
+  }
+  .hamburger {
+    display: flex;
+  }
+}

--- a/flamecoin-site/src/layouts/BaseLayout.astro
+++ b/flamecoin-site/src/layouts/BaseLayout.astro
@@ -1,0 +1,19 @@
+---
+import NavBar from '../components/NavBar.astro';
+import Footer from '../components/Footer.astro';
+const { title = 'FlameCoin' } = Astro.props;
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{title}</title>
+    <link rel="stylesheet" href="/styles/tokens.css" />
+  </head>
+  <body style="font-family: var(--font-display); background: var(--ash); color: var(--charcoal);">
+    <NavBar />
+    <main>
+      <slot />
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/flamecoin-site/src/pages/blog/index.mdx
+++ b/flamecoin-site/src/pages/blog/index.mdx
@@ -1,3 +1,12 @@
+---
+title: Blog
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+<BaseLayout title="Blog">
+
 # Blog
 
 Coming soon.
+
+</BaseLayout>

--- a/flamecoin-site/src/pages/docs/index.mdx
+++ b/flamecoin-site/src/pages/docs/index.mdx
@@ -1,3 +1,12 @@
+---
+title: Documentation
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+<BaseLayout title="Documentation">
+
 # Documentation
 
 Welcome to the docs.
+
+</BaseLayout>

--- a/flamecoin-site/src/pages/index.astro
+++ b/flamecoin-site/src/pages/index.astro
@@ -1,18 +1,8 @@
 ---
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>FlameCoin</title>
-    <link rel="stylesheet" href="/styles/tokens.css" />
-  </head>
-  <body style="font-family: var(--font-display); background: var(--ash); color: var(--charcoal);">
-    <header>
-      <h1>FlameCoin</h1>
-    </header>
-    <main>
-      <h2>The future of decentralized fire.</h2>
-      <a href="/story">Read the story</a>
-    </main>
-  </body>
-</html>
+<BaseLayout title="FlameCoin">
+  <h1>FlameCoin</h1>
+  <h2>The future of decentralized fire.</h2>
+  <a href="/story">Read the story</a>
+</BaseLayout>

--- a/flamecoin-site/src/pages/story.mdx
+++ b/flamecoin-site/src/pages/story.mdx
@@ -1,3 +1,12 @@
+---
+title: FlameCoin Story
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+<BaseLayout title="FlameCoin Story">
+
 # FlameCoin Story
 
 The cultural narrative.
+
+</BaseLayout>

--- a/flamecoin-site/src/pages/team.astro
+++ b/flamecoin-site/src/pages/team.astro
@@ -1,7 +1,6 @@
 ---
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
-<html>
-  <body>
-    <h1>Our Team</h1>
-  </body>
-</html>
+<BaseLayout title="Our Team">
+  <h1>Our Team</h1>
+</BaseLayout>

--- a/flamecoin-site/src/pages/tech.mdx
+++ b/flamecoin-site/src/pages/tech.mdx
@@ -1,3 +1,12 @@
+---
+title: FlameCoin Tech
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+<BaseLayout title="FlameCoin Tech">
+
 # FlameCoin Tech
 
 High-level architecture.
+
+</BaseLayout>


### PR DESCRIPTION
## Summary
- create BaseLayout for shared html structure
- add NavBar component with FlameCoin links
- style nav and mobile hamburger menu
- wrap existing pages in BaseLayout
- add footer placeholder

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866a9444840832e91a58254231b0427