### PR TITLE
feat/layout-global-navbar

### DIFF
--- a/flamecoin-site/src/components/NavBar.astro
+++ b/flamecoin-site/src/components/NavBar.astro
@@ -1,0 +1,21 @@
+---
+import './NavBar.css';
+---
+
+<nav class="navbar">
+  <a href="/" class="logo">
+    <img src="/logo.svg" alt="FlameCoin logo" width="40" height="40" />
+  </a>
+  <input id="menu-toggle" type="checkbox" class="menu-toggle" />
+  <label for="menu-toggle" class="hamburger" aria-label="Menu">
+    <span></span>
+  </label>
+  <ul class="menu">
+    <li><a href="/">Home</a></li>
+    <li><a href="/docs">Docs</a></li>
+    <li><a href="/tokenomics">Tokenomics</a></li>
+    <li><a href="/story">Story</a></li>
+    <li><a href="/team">Team</a></li>
+    <li><a href="/blog">Blog</a></li>
+  </ul>
+</nav>

--- a/flamecoin-site/src/components/NavBar.css
+++ b/flamecoin-site/src/components/NavBar.css
@@ -1,0 +1,58 @@
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: var(--ash);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.menu-toggle {
+  display: none;
+}
+
+.hamburger {
+  display: block;
+  cursor: pointer;
+}
+.hamburger span,
+.hamburger::before,
+.hamburger::after {
+  content: '';
+  display: block;
+  width: 1.5rem;
+  height: 2px;
+  background: var(--charcoal);
+  margin: 4px 0;
+  transition: transform 0.3s;
+}
+
+.menu {
+  display: none;
+  flex-direction: column;
+  margin-top: 0.5rem;
+}
+.menu a {
+  text-decoration: none;
+  color: var(--charcoal);
+  padding: 0.25rem 0;
+}
+
+.menu-toggle:checked ~ .menu {
+  display: flex;
+}
+
+@media (min-width: 768px) {
+  .hamburger {
+    display: none;
+  }
+  .menu {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 0;
+  }
+}

--- a/flamecoin-site/src/layouts/BaseLayout.astro
+++ b/flamecoin-site/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import NavBar from '../components/NavBar.astro';
 const { title = 'FlameCoin', description } = Astro.props;
 ---
 
@@ -6,24 +7,15 @@ const { title = 'FlameCoin', description } = Astro.props;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
-
-    <link rel="stylesheet" href="/styles/tokens.css" />
+    <link rel="stylesheet" href="/styles/global.css" />
   </head>
-
-  <body
-    style="font-family: var(--font-display); background: var(--ash); color: var(--charcoal);"
-  >
-    <header>
-      <h1>FlameCoin</h1>
-    </header>
-
+  <body style="font-family: var(--font-display); background: var(--ash); color: var(--charcoal);">
+    <NavBar />
     <main>
       <slot />
     </main>
-
-    <footer>© 2025 FlameCoin</footer>
+    <footer class="site-footer">© 2025 FlameCoin</footer>
   </body>
 </html>

--- a/flamecoin-site/src/pages/index.astro
+++ b/flamecoin-site/src/pages/index.astro
@@ -1,28 +1,10 @@
 ---
-  codex/create-hero-section-with-cta
 import Hero from '../components/Hero.astro';
-layout: "../layouts/BaseLayout.astro"
-        main
+layout: '../layouts/BaseLayout.astro'
 ---
- codex/migrate-pages-to-layout
+
+<Hero />
 <h2>The future of decentralized fire.</h2>
+<div class="bg-flame-500 text-white p-4 mt-4">Powered by Tailwind</div>
 <a href="/story">Read the story</a>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>FlameCoin</title>
-    <link rel="stylesheet" href="/styles/global.css" />
-  </head>
-  <body style="font-family: var(--font-display); background: var(--ash); color: var(--charcoal);">
-    <header>
-      <h1>FlameCoin</h1>
-    </header>
-    <main>
-      <Hero />
-      <h2>The future of decentralized fire.</h2>
-      <div class="bg-flame-500 text-white p-4 mt-4">Powered by Tailwind</div>
-      <a href="/story">Read the story</a>
-    </main>
-  </body>
-</html>
- main
+


### PR DESCRIPTION
## Summary
- add responsive `NavBar` component
- style navigation with `NavBar.css`
- update `BaseLayout` to use `NavBar` and footer
- clean up `index.astro` to use layout and hero

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866b2162b04832e99ec83e92f4ecfc9